### PR TITLE
fix: vanilla start button

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -483,7 +483,7 @@ impl Handler {
 
         if origin {
             if game_origin.exists() {
-                std::process::Command::new(game_origin).spawn().unwrap();
+                std::process::Command::new(game_origin).arg("--vanilla").spawn().unwrap();
             } else {
                 std::process::Command::new(game).spawn().unwrap();
             }


### PR DESCRIPTION
修复了启动原版按钮仍然启动 everest 的 bug