### PR TITLE
在 Linux 系统中选择游戏路径

### DIFF
--- a/src/celemod-ui/src/components/GameSelector.tsx
+++ b/src/celemod-ui/src/components/GameSelector.tsx
@@ -10,7 +10,6 @@ export const GameSelector = (props: {
   onSelect: any;
   launchGame: (v: string) => void;
 }) => {
-  if (!props.paths.length) return <div>No games found</div>;
   const [gamePath] = useGamePath();
 
   if (!props.paths.includes(gamePath)) {

--- a/src/celemod-ui/src/components/ModList.tsx
+++ b/src/celemod-ui/src/components/ModList.tsx
@@ -17,7 +17,7 @@ import { useGlobalContext } from '../App';
 import { PopupContext, createPopup } from './Popup';
 import { ProgressIndicator } from './Progress';
 // @ts-ignore
-import celemodIcon from '../resources/celemod.png';
+import celemodIcon from '../resources/Celemod.png';
 
 const processLargeNum = (num: number) => {
   if (num < 1000) return num.toString();

--- a/src/celemod-ui/src/utils.ts
+++ b/src/celemod-ui/src/utils.ts
@@ -1,5 +1,6 @@
 import { useState } from "preact/hooks";
 import { useEffect } from "react";
+import { dirname } from "path";
 
 export const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -113,14 +114,13 @@ export const selectGamePath = (successCallback) => {
     // @ts-ignore
     const res = Window.this.selectFile({
         mode: 'open',
-        filter: 'Celeste.exe|Celeste.exe',
+        filter: 'Celeste.exe (Windows)|Celeste.exe|' + 'Celeste (*nix)|Celeste',
     });
     if (res !== null) {
         // strip file:// and Celeste.exe
-        const before = 'file://'.length;
-        const after = 'celeste.exe'.length;
+        const prefix = 'file://'.length;
         const decoded = decodeURI(res)
-        const path = decoded.slice(before, decoded.length - after);
+        const path = dirname(decoded.slice(prefix));
         console.log('Selected', path);
         successCallback(path);
         return path

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,8 +485,14 @@ impl Handler {
     }
 
     fn start_game_directly(&self, path: String, origin: bool) {
-        let game = Path::new(&path).join("Celeste.exe");
-        let game_origin = Path::new(&path).join("orig").join("Celeste.exe");
+        #[cfg(windows)]
+        let file = "Celeste.exe";
+
+        #[cfg(unix)]
+        let file = "Celeste";
+
+        let game = Path::new(&path).join(file);
+        let game_origin = Path::new(&path).join("orig").join(file);
 
         if origin {
             if game_origin.exists() {
@@ -755,7 +761,7 @@ impl Handler {
 
     fn verify_celeste_install(&self, path: String) -> bool {
         let path = Path::new(&path);
-        let checklist = vec!["Celeste.exe"];
+        let checklist = vec!["Celeste.exe", "Celeste"];
         for file in checklist {
             if path.join(file).exists() {
                 return true;


### PR DESCRIPTION
您好！我尝试添加了一些对于 Linux 的适配，主要是选择路径时可以选择 `Celeste.exe` 或 `Celeste`，以及启动游戏时执行 `Celeste`。

只提交了源代码，没有更新 `dist.rc`。
