### PR TITLE
Update rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,21 +31,31 @@ jobs:
           ./target/release/cele-mod.exe
           ./target/release/aria2c.exe
           ./target/release/sciter.dll
-  build-linux:
+    build-linux:
     runs-on: ubuntu-20.04
     steps:
     - name: Install dependencies
-      run: sudo cat deb http://archive.ubuntu.com/ubuntu focal-updates main >> /etc/apt/sources.list & sudo apt-get update & sudo apt-get install -y pkg-config cmake clang libpango-1.0-0 librust-atk-dev gdk-3.0
+      run: |
+        sudo sh -c 'echo "deb http://archive.ubuntu.com/ubuntu focal-updates main" > /etc/apt/sources.list.d/focal-updates.list'
+        sudo apt-get update
+        sudo apt-get install -y \
+          pkg-config \
+          cmake \
+          clang \
+          libpango-1.0-0 \
+          libatk1.0-dev \
+          libgdk-pixbuf2.0-0
     - uses: actions/checkout@v3
     - name: Install latest nightly
       uses: actions-rs/toolchain@v1
       with:
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy
+        toolchain: nightly
+        override: true
+        components: rustfmt, clippy
     - name: Build Rust
       run: cargo build --verbose --release
     - uses: actions/upload-artifact@v4.3.1
       with:
         name: linux
-        path: ./target/release/cele-mod
+        path: |
+          ./target/release/cele-mod


### PR DESCRIPTION
Dependency Installation Command: The command for adding the repository to the sources list has been fixed. Also, the package names have been corrected (librust-atk-dev to libatk1.0-dev, and gdk-3.0 to libgdk-pixbuf2.0-0).

Shell Command Delimiter: I used | to pass the commands as a string to sudo sh -c.

Package Installation: I split the packages into separate lines for better readability and added indentation for clarity.