### PR TITLE
mod配置界面的一个优化

### DIFF
--- a/src/celemod-ui/src/context/blacklist.ts
+++ b/src/celemod-ui/src/context/blacklist.ts
@@ -20,6 +20,7 @@ export const createBlacklistContext = () => {
             console.log('switch to profile', name);
             callRemote('apply_blacklist_profile', gamePath, name, JSON.stringify(alwaysOnMods));
             setCurrentProfileName(name);
+            setCurrentProfile(profiles.find(p => p.name === name) || profiles[0]);
         },
     }
 


### PR DESCRIPTION
使用cele-mod时，在mod配置界面右侧切换profile时，左边的mod情况却没有改变，使用起来比较反直觉。
查看代码后在切换profile时添加了对currentProfile的更新，现在切换profile会显示对应的mod列表了。