### PR TITLE
fix: 修编译错误

### DIFF
--- a/src/everest.rs
+++ b/src/everest.rs
@@ -188,7 +188,7 @@ fn run_command(
     let mut line_count = 0f32;
     for line in reader.lines() {
         let line = line?;
-        line_count = (line_count + 1).min(99.0);
+        line_count = (line_count + 1.0).min(99.0);
         progress_callback(format!("[3/3] Run MiniInstaller: {line}"), line_count);
     }
 


### PR DESCRIPTION
就现在 Actions 里面报的那个

另外我之前加了一个 Build.yml，会先编译前端，再编译整个软件（就是开头比 rust.yml 多一步），这样就不用必须先本地编译一遍前端了。

所以现在有两套几乎一样的 workflow，你看着删一个吧（